### PR TITLE
Use sudo version to `1.9.16p2-3` for `1877`

### DIFF
--- a/prepare_source
+++ b/prepare_source
@@ -1,1 +1,6 @@
-git_src -b debian/1.9.16p2-3 https://salsa.debian.org/sudo-team/sudo.git
+pkg=sudo
+version_orig=1.9.16p2-3
+version="$version_orig"
+git_src -b "debian/$version_orig" https://salsa.debian.org/sudo-team/sudo.git
+
+version_suffix=gl0+bp1877


### PR DESCRIPTION
**What this PR does / why we need it**:
 This PR uses "sudo" with version `1.9.16p2-3` for GardenLinux release `1877.2`.

**Which issue(s) this PR fixes**:
Related https://github.com/gardenlinux/gardenlinux/issues/3197